### PR TITLE
update travis test environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: node_js
 node_js:
-  - 0.6
-  - 0.8
-  - 0.9
+  - "0.6"
+  - "0.8"
+  - "0.10"
+  - "0.11"
 
 notifications:
   email:


### PR DESCRIPTION
In order to continue development it might be good to update the travis test environments. Also there is no point in testing on the v0.9 release anymore.

Note: at least one test case is failing when running node v0.10 or v0.11. But that is another issue.

> FAILURES: Undone tests (or their setups/teardowns): 
> - Secure connection - STARTTLS on secure server fails
> To fix this, make sure all tests call test.done()
- Remove old development branch v0.9
- Add latest stable version v0.10
- Add latest development branch v0.11
