### PR TITLE
add support for returning all data in runClientMockup

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,13 +134,16 @@ By default it's `"."` which is suitable for SMTP and POP3.
 ## Testing
 
 There is a possibility to set up a mockup client which sends a batch of commands
-one by one to the server and returns the last response.
+one by one to the server and returns the last response and an array of all responses(except the TLS negotiation).
 
     var runClientMockup = require("rai").runClientMockup;
     
     var cmds = ["EHLO FOOBAR", "STARTTLS", "QUIT"];
-    runClientMockup(25, "mail.hot.ee", cmds, function(resp){
-        console.log("Final:", resp.toString("utf-8").trim());
+    runClientMockup(25, "mail.hot.ee", cmds, function(lastResponse, allResponses){
+        console.log("Final:", lastResponse.toString("utf-8").trim());
+        console.log("All:", allResponses.map(function(e){
+            return e.toString("utf-8").trim()
+        }).join(', '));
     });
 
 `runClientMockup` has he following parameters in the following order:
@@ -152,7 +155,7 @@ one by one to the server and returns the last response.
   * **debug** - if set to true log all input/output
 
 Response from the callback function is a Buffer and contains the
-last data received from the server
+last data received from the server and an array of Buffers with all data received from the server.
 
 ## License
 

--- a/lib/mockup.js
+++ b/lib/mockup.js
@@ -40,7 +40,7 @@ function runClientMockup(port, host, commands, callback, debug){
     port = port || 25;
     commands = Array.isArray(commands) ? commands : [];
 
-    var command, ignore_data = false, sslcontext, pair;
+    var command, ignore_data = false, responses = [], sslcontext, pair;
 
     var socket = net.connect(port, host);
     socket.on("connect", function(){
@@ -54,9 +54,12 @@ function runClientMockup(port, host, commands, callback, debug){
             if(!commands.length){
                 socket.end();
                 if(typeof callback == "function"){
-                    callback(chunk);
+                    responses.push(chunk);
+                    callback(chunk, responses);
                 }
                 return;
+            }else{
+                responses.push(chunk);
             }
             
             if(["STARTTLS", "STLS"].indexOf((command || "").trim().toUpperCase())>=0){
@@ -89,9 +92,12 @@ function runClientMockup(port, host, commands, callback, debug){
                         if(!commands.length){
                             pair.cleartext.end();
                             if(typeof callback == "function"){
-                                callback(chunk);
+                                responses.push(chunk);
+                                callback(chunk, responses);
                             }
                             return;
+                        }else{
+                            responses.push(chunk);
                         }
                         command = commands.shift();
                         pair.cleartext.write(command+"\r\n");

--- a/test/rai.js
+++ b/test/rai.js
@@ -1,4 +1,5 @@
 var RAIServer = require("../lib/rai").RAIServer,
+    runClientMockup = require("../lib/rai").runClientMockup,
     testCase = require('nodeunit').testCase,
     utillib = require("util"),
     netlib = require("net"),
@@ -586,4 +587,162 @@ exports["Timeout tests"] = {
 
         });
     } 
+};
+
+exports["Client Mockup"] = {
+    "All command": function(test){
+        var server = new RAIServer();
+        server.listen(PORT_NUMBER, function(err){
+            server.on("connect", function(socket){
+                socket.send("220 Welcome");
+                socket.on("command", function(command, payload){
+                    switch(command) {
+                        case "HELO": socket.send("250 HI"); break;
+                        case "NOOP": socket.send("250 OK"); break;
+                        case "QUIT": socket.send("221 Bye"); socket.end(); break;
+                        default: socket.send("500");
+                    }
+                });
+
+                socket.on("error", function(err){
+                    test.isError(err);
+                });
+            });
+
+            var cmds = ["HELO", "NOOP", "QUIT"];
+            runClientMockup(PORT_NUMBER, "localhost", cmds, function(lastResponse, allResponses){
+                allResponses = allResponses.map(function(value) { return value.toString("utf-8"); });
+                test.deepEqual(allResponses, [ "220 Welcome\r\n", "250 HI\r\n", "250 OK\r\n", "221 Bye\r\n" ]);
+                server.end(function(){
+                    test.done();
+                });
+
+            });
+
+        });
+    },
+    "Last commands":  function(test){
+        var server = new RAIServer();
+        server.listen(PORT_NUMBER, function(err){
+            server.on("connect", function(socket){
+                socket.send("220 HI");
+                socket.on("command", function(command, payload){
+                    switch(command) {
+                        case "HELO": socket.send("250 HI"); break;
+                        case "NOOP": socket.send("250 OK"); break;
+                        case "QUIT": socket.send("221 Bye"); socket.end(); break;
+                        default: socket.send("500");
+                    }
+                });
+
+                socket.on("error", function(err){
+                    test.isError(err);
+                });
+            });
+
+            var cmds = ["HELO", "NOOP", "QUIT"];
+            runClientMockup(PORT_NUMBER, "localhost", cmds, function(lastResponse){
+                test.equal(lastResponse.toString("utf-8"), "221 Bye\r\n");
+                server.end(function(){
+                    test.done();
+                });
+
+            });
+
+        });
+    },
+    "All command(STARTTLS)": function(test){
+        var server = new RAIServer();
+        server.listen(PORT_NUMBER, function(err){
+
+            test.expect(2);
+
+            server.on("connect", function(socket){
+                socket.tlsStatus = 0;
+                socket.send("220 Welcome");
+                socket.on("command", function(command, payload){
+                    switch(command){
+                        case "EHLO":
+                            if(socket.tlsStatus===0){
+                                socket.send("250-HI\r\n250 STARTTLS");
+                            }else{
+                                socket.send("250 HI");
+                            }
+                            break;
+                        case "NOOP": socket.send("250 OK"); break;
+                        case "QUIT": socket.send("221 Bye"); socket.end(); break;
+                        case "STARTTLS": socket.startTLS(); socket.send("220 Go ahead"); break;
+                        default: socket.send("500");
+                    }
+                });
+
+                socket.on("tls", function(){
+                    test.ok(1, "Secure connection opened");
+                    socket.tlsStatus = 1;
+                });
+
+                socket.on("error", function(err){
+                    test.isError(err);
+                });
+            });
+
+            var cmds = ["EHLO", "STARTTLS", "EHLO", "NOOP", "QUIT"];
+            runClientMockup(PORT_NUMBER, "localhost", cmds, function(lastResponse, allResponses){
+                allResponses = allResponses.map(function(value) { return value.toString("utf-8"); });
+                test.deepEqual(allResponses, ["220 Welcome\r\n", "250-HI\r\n250 STARTTLS\r\n", "220 Go ahead\r\n",
+                                              "250 HI\r\n", "250 OK\r\n", "221 Bye\r\n" ]);
+                server.end(function(){
+                    test.done();
+                });
+
+            });
+
+        });
+    },
+    "Last commands(STARTTLS)":  function(test){
+        var server = new RAIServer();
+        server.listen(PORT_NUMBER, function(err){
+
+            test.expect(2);
+
+            server.on("connect", function(socket){
+                socket.tlsStatus = 0;
+                socket.send("220 Welcome");
+                socket.on("command", function(command, payload){
+                    switch(command){
+                        case "EHLO":
+                            if(socket.tlsStatus===0){
+                                socket.send("250-HI\r\n250 STARTTLS");
+                            }else{
+                                socket.send("250 HI");
+                            }
+                            break;
+                        case "NOOP": socket.send("250 OK"); break;
+                        case "QUIT": socket.send("221 Bye"); socket.end(); break;
+                        case "STARTTLS": socket.startTLS(); socket.send("220 Go ahead"); break;
+                        default: socket.send("500");
+                    }
+                });
+
+                socket.on("tls", function(){
+                    test.ok(1, "Secure connection opened");
+                    socket.tlsStatus = 1;
+                });
+
+                socket.on("error", function(err){
+                    test.isError(err);
+                });
+            });
+
+            var cmds = ["EHLO", "STARTTLS", "EHLO", "NOOP", "QUIT"];
+            runClientMockup(PORT_NUMBER, "localhost", cmds, function(lastResponse){
+                test.equal(lastResponse.toString("utf-8"), "221 Bye\r\n");
+                server.end(function(){
+                    test.done();
+                });
+
+            });
+
+        });
+    }
 };


### PR DESCRIPTION
This feature is usable to test a whole transaction session. If you just get the last response there might be a problem in the middle that you do not find. E.g.;

> S: 220 HI
> C: HELO
> S: 250 OK
> C: MAIL FROM:<a@a.a>
> S: 250 OK
> C: RCPT TO:<b@b.b>
> S: 550 <-- you will miss this one for example
> C: RCPT TO:<b@b.a>
> S: 250 OK

The API change is trivial; adding a second parameter to the callback. By doing so, we have full backward compatibility.

My tests passes in all versions specified in `.travis.yml` except in v0.11.6 where nothing seams to work due to `createSecurePair() is deprecated, use TLSSocket instead`.

I have tried to follow your coding style, but please fix/tell me what is wrong if you are not satisfied.

**Commit message;**
- return a second argument in the callback with all the responses
- tests
- documentation
