### PR TITLE
properly handle chunks that are split with only a dot remaining

### DIFF
--- a/lib/rai.js
+++ b/lib/rai.js
@@ -204,7 +204,7 @@ function RAISocket(socket, options){
 
     this._dataMode = false;
     this._endDataModeSequence = "\r\n.\r\n";
-    this._endDataModeSequenceRegEx = /\r\n\.\r\n|^\.\r\n/;
+    this._endDataModeSequenceRegEx = /\r\n\.\r\n/;
 
     this.secureConnection = !!this.options.secureConnection;
     this._destroyed = false;
@@ -256,7 +256,7 @@ RAISocket.prototype.startDataMode = function(sequence){
     if(sequence){
         sequence = sequence.replace(/([\.\=\(\)\-\?\*\\\[\]\^\+\:\|\,])/g, "\\$1");
         this._endDataModeSequence = "\r\n"+sequence+"\r\n";
-        this._endDataModeSequenceRegEx = new RegExp("\\r\\n" + sequence + "\\r\\n|^"+sequence+"\\r\\n");
+        this._endDataModeSequenceRegEx = new RegExp("\\r\\n" + sequence + "\\r\\n");
     }
 };
 
@@ -338,22 +338,16 @@ RAISocket.prototype._onReceiveData = function(chunk){
     }
 
     var str = typeof chunk=="string"?chunk:chunk.toString("binary"),
-        dataEndMatch, dataRemainderMatch, data, match;
+        dataRemainderMatch, data;
 
     if(this._dataMode){
 
+        // prefix the incoming chunk with the remainder of the previous chunk
         str = this._remainder + str;
-        if((dataEndMatch = str.match(/\r\n.*?$/))){
-            // if ther's a line that is not ended, keep it for later
-            this._remainder = str.substr(dataEndMatch.index);
-            str = str.substr(0, dataEndMatch.index);
-        }else{
-            this._remainder = "";
-        }
+        this._remainder = "";
 
         // check if a data end sequence is found from the data
-        if((dataRemainderMatch = (str+this._remainder).match(this._endDataModeSequenceRegEx))){
-            str = str + this._remainder;
+        if((dataRemainderMatch = str.match(this._endDataModeSequenceRegEx))){
             // if the sequence is not on byte 0 emit remaining data
             if(dataRemainderMatch.index){
                 data = new Buffer(str.substr(0, dataRemainderMatch.index), "binary");
@@ -361,7 +355,6 @@ RAISocket.prototype._onReceiveData = function(chunk){
                 this.emit("data", data);
             }
             // emit data ready
-            this._remainder = "";
             this.emit("ready");
             this._dataMode = false;
             // send the remaining data for processing
@@ -369,17 +362,14 @@ RAISocket.prototype._onReceiveData = function(chunk){
         }else{
             // check if there's not something in the end of the data that resembles
             // end sequence - if so, cut it off and save it to the remainder
-            str = str + this._remainder;
-            this._remainder=  "";
             for(var i = Math.min(this._endDataModeSequence.length-1, str.length); i>0; i--){
-                match = this._endDataModeSequence.substr(0, i);
-                if(str.substr(-match.length) == match){
-                    this._remainder = str.substr(-match.length);
-                    str = str.substr(0, str.length - match.length);
+                if(str.substr(-i) == this._endDataModeSequence.substr(0, i)){
+                    this._remainder = str.substr(-i);
+                    str = str.substr(0, str.length - i);
                 }
             }
 
-            // if there's some data leht, emit it
+            // if there's some data left, emit it
             if(str.length){
                 data = new Buffer(str, "binary");
                 this._logger("DATA:", data.toString("utf-8"));


### PR DESCRIPTION
RAI currently fails to handle when the data in chunked in the middle of the line, so the preceding chunk does not end with a newline, and the succeeding chunk has only a dot remaining from that line.

Here is an example (in JS string notation) that will successfully work in a single chunk:
 "This is a valid sentence.\r\nThis is the final sentence.\r\n.\r\n"

But if the data is split immediately following either "sentence", then the following ".\r\n" will be matched at the start of the next chunk, which will cause it to switch out of data mode, and the remaining data will be incorrectly interpreted as commands.

To solve this problem, it was as simple as removing "^\.\r\n" from the regex.  I suspect that this was present from earlier revisions of the code, because removing it does not affect proper handling when next-to-last chunk ends with "\r\n" and the final chunk is only ".\r\n", since the trailing "\r\n" of the next-to-last chunk will be preserved as this._remainder, and str will become "\r\n\.r\n" when handling the final chunk.  If I've overlooked something, please let me know.

Other than the regex change, I've simplified the logic of _onReceiveData -- there should be no functional change here, only the removal of redundant splitting/assignments/variables.