### PR TITLE
Removed use of deprecated createCredentials() method if run under nod…

### DIFF
--- a/lib/mockup.js
+++ b/lib/mockup.js
@@ -71,7 +71,11 @@ function runClientMockup(port, host, commands, callback, debug){
                 if(debug){
                     console.log("Initiated TLS connection");
                 }
-                sslcontext = crypto.createCredentials();
+				if (tls.createSecureContext) {
+					sslcontext = tls.createSecureContext();
+				} else {
+					sslcontext = crypto.createCredentials();
+				}
                 pair = tlslib.createSecurePair(sslcontext, false);
 
                 pair.encrypted.pipe(socket);

--- a/lib/starttls.js
+++ b/lib/starttls.js
@@ -24,6 +24,9 @@
  */
 module.exports.starttls = starttls;
 
+var tls = require("tls");
+var crypto = require("crypto");
+
 /**
  * <p>Upgrades a socket to a secure TLS connection</p>
  *
@@ -36,8 +39,13 @@ function starttls(socket, options, callback) {
     var sslcontext, pair, cleartext;
 
     socket.removeAllListeners("data");
-    sslcontext = require('crypto').createCredentials(options);
-    pair = require('tls').createSecurePair(sslcontext, true);
+	if (tls.createSecureContext) {
+		sslcontext = tls.createSecureContext(options);
+	} else {
+		// deprecated in node 0.11+
+		sslcontext = crypto.createCredentials(options);
+	}
+    pair = tls.createSecurePair(sslcontext, true);
     cleartext = pipe(pair, socket);
 
     pair.on('secure', function() {


### PR DESCRIPTION
In Node 0.11+, the createCredentials() method is deprecated and a warning is generated on the console. I added an if-statement to use its replacement when run under Node 0.11+, so that the warning is avoided and it still works under node 0.10
